### PR TITLE
Extra boot opts

### DIFF
--- a/airgap-boot.nix
+++ b/airgap-boot.nix
@@ -335,7 +335,7 @@ in {
 
         "org/gnome/desktop/lockdown" = {
           disable-lock-screen = true;
-          disable-log-out = true;
+          disable-log-out = false;
           disable-user-switching = true;
         };
 

--- a/airgap-boot.nix
+++ b/airgap-boot.nix
@@ -370,7 +370,7 @@ in {
         };
 
         "org/gnome/shell" = {
-          welcome-dialog-last-shown-version = "41.2";
+          welcome-dialog-last-shown-version = "${toString pkgs.gdm.version}";
         };
       };
     }

--- a/airgap-boot.nix
+++ b/airgap-boot.nix
@@ -94,10 +94,13 @@ in {
         dconf-editor
         glibc
         gnupg
+        gnutar
+        gzip
         jq
         lvm2
         neovim
         openssl
+        p7zip
         pcsc-tools
         pinentry-all
         pwgen
@@ -106,8 +109,13 @@ in {
         sqlite-interactive
         step-cli
         tinyxxd
+        tmux
+        unzip
         usbutils
         util-linux
+        xz
+        yubikey-manager
+        zip
       ]);
 
     variables = {

--- a/airgap-boot.nix
+++ b/airgap-boot.nix
@@ -87,13 +87,13 @@ in {
         shutdown
       ]
       ++ (with pkgs; [
+        adwaita-icon-theme
         ccid
         cfssl
         cryptsetup
+        dconf-editor
         glibc
-        adwaita-icon-theme
         gnupg
-        python3Packages.ipython
         jq
         lvm2
         neovim
@@ -101,6 +101,7 @@ in {
         pcsc-tools
         pinentry-all
         pwgen
+        python3Packages.ipython
         smem
         sqlite-interactive
         step-cli
@@ -317,55 +318,59 @@ in {
     Hidden=false
   '';
 
-  systemd.user.services.dconf-defaults = {
-    script = let
-      dconfDefaults = pkgs.writeText "dconf.defaults" ''
-        [org/gnome/desktop/background]
-        color-shading-type='solid'
-        picture-options='zoom'
-        picture-uri='${./cardano.png}'
-        primary-color='#000000000000'
-        secondary-color='#000000000000'
+  programs.dconf.profiles.user.databases = [
+    {
+      settings = {
+        "org/gnome/desktop/background" = {
+          color-shading-type = "solid";
+          picture-options = "zoom";
+          picture-uri = "${./cardano.png}";
+          primary-color = "#000000000000";
+          secondary-color = "#000000000000";
+        };
 
-        [org/gnome/desktop/lockdown]
-        disable-lock-screen=true
-        disable-log-out=true
-        disable-user-switching=true
+        "org/gnome/desktop/lockdown" = {
+          disable-lock-screen = true;
+          disable-log-out = true;
+          disable-user-switching = true;
+        };
 
-        [org/gnome/desktop/notifications]
-        show-in-lock-screen=false
+        "org/gnome/desktop/notifications" = {
+          show-in-lock-screen = false;
+        };
 
-        [org/gnome/desktop/screensaver]
-        color-shading-type='solid'
-        lock-delay=uint32 0
-        lock-enabled=false
-        picture-options='zoom'
-        picture-uri='${./cardano.png}'
-        primary-color='#000000000000'
-        secondary-color='#000000000000'
+        "org/gnome/desktop/screensaver" = {
+          color-shading-type = "solid";
+          lock-delay = lib.gvariant.mkUint32 0;
+          lock-enabled = false;
+          picture-options = "zoom";
+          picture-uri = "${./cardano.png}";
+          primary-color = "#000000000000";
+          secondary-color = "#000000000000";
+        };
 
-        [org/gnome/settings-daemon/plugins/media-keys]
-        custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/']
+        "org/gnome/settings-daemon/plugins/media-keys" = {
+          custom-keybindings = ["/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"];
+        };
 
-        [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
-        binding='<Primary><Alt>t'
-        command='kgx'
-        name='console'
+        "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0" = {
+          binding = "<Primary><Alt>t";
+          command = "kgx";
+          name = "console";
+        };
 
-        [org/gnome/settings-daemon/plugins/power]
-        idle-dim=false
-        power-button-action='interactive'
-        sleep-inactive-ac-type='nothing'
+        "org/gnome/settings-daemon/plugins/power" = {
+          idle-dim = false;
+          power-button-action = "interactive";
+          sleep-inactive-ac-type = "nothing";
+        };
 
-        [org/gnome/shell]
-        welcome-dialog-last-shown-version='41.2'
-      '';
-    in ''
-      ${pkgs.dconf}/bin/dconf load / < ${dconfDefaults}
-    '';
-    wantedBy = ["graphical-session.target"];
-    partOf = ["graphical-session.target"];
-  };
+        "org/gnome/shell" = {
+          welcome-dialog-last-shown-version = "41.2";
+        };
+      };
+    }
+  ];
 
   users = {
     allowNoPasswordLogin = true;

--- a/airgap-boot.nix
+++ b/airgap-boot.nix
@@ -321,6 +321,10 @@ in {
   programs.dconf.profiles.user.databases = [
     {
       settings = {
+        "org/gnome/Console" = {
+          last-window-maximised = true;
+        };
+
         "org/gnome/desktop/background" = {
           color-shading-type = "solid";
           picture-options = "zoom";

--- a/flake.lock
+++ b/flake.lock
@@ -3348,11 +3348,11 @@
     },
     "nixpkgs_18": {
       "locked": {
-        "lastModified": 1748302896,
-        "narHash": "sha256-ixMT0a8mM091vSswlTORZj93WQAJsRNmEvqLL+qwTFM=",
+        "lastModified": 1758346548,
+        "narHash": "sha256-afXE7AJ7MY6wY1pg/Y6UPHNYPy5GtUKeBkrZZ/gC71E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7848cd8c982f7740edf76ddb3b43d234cb80fc4d",
+        "rev": "b2a3852bd078e68dd2b3dfa8c00c67af1f0a7d20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
* Adds more boot options for better video driver support:
  * `Generic Video` -- the prior default, autoselects for Intel/AMD/Nvidia/etc drivers with open source kernel modules
  * `Nouveau (nomodeset, $version)`  -- a more capable fallback than a full nomodeset for Nvidia cards
  * `NVIDIA (prop, $version)` -- Nvidia closed source driver w/ license included in the ISO
  * `NVIDIA (open, $version)` -- Nvidia open source driver
* Dconf-editor was added to systemPackages for enhanced dconf system discovery
* The dconf systemd service was converted to the nixos module `programs.dconf.profiles.users.databases` option
* The gnome-shell versioning for dconf was updated to stay matched with the nix build
* The console started on system boot now starts maximized, with the second desktop still visible until console is clicked
* The dconf `disable-log-out` has been set to false to allow shutdown, restarts and logouts from the Gnome GUI
* Some additional helper system packages were added such as compression utilities, tmux and yubikey manager for airgap yubikey setup and key-rotation.